### PR TITLE
use method call for `one` - typo

### DIFF
--- a/content/manual/source/common/dataManager_4.java
+++ b/content/manual/source/common/dataManager_4.java
@@ -2,7 +2,7 @@
 private DataManager dataManager;
 
 private Book loadBookById(UUID bookId) {
-    return dataManager.load(Book.class).id(bookId).view("book.edit").one;
+    return dataManager.load(Book.class).id(bookId).view("book.edit").one();
 }
 
 private List<BookPublication> loadBookPublications(UUID bookId) {


### PR DESCRIPTION
There was probably a typo that loads one instance through `dataManager`.