### PR TITLE
Default haulmont location forms

### DIFF
--- a/content/bpm/adoc/ru/ui_components/process_forms.adoc
+++ b/content/bpm/adoc/ru/ui_components/process_forms.adoc
@@ -49,7 +49,7 @@
 +
 [source]
 ----
-bpm.formsConfig = bpm-forms.xml app-bpm-forms.xml
+bpm.formsConfig = com/haulmont/bpm/forms.xml app-bpm-forms.xml
 ----
 --
 


### PR DESCRIPTION
Fix location of default bpm forms xml