### PR TITLE
Adjusted custom Icon implementation example

### DIFF
--- a/content/manual/adoc/en/framework/gui_framework/gui_icons/icon_set.adoc
+++ b/content/manual/adoc/en/framework/gui_framework/gui_icons/icon_set.adoc
@@ -31,6 +31,11 @@ public enum MyIcon implements Icons.Icon {
     public String source() {
         return source;
     }
+    
+    @Override
+    public String iconName() {
+        return name();
+    }
 }
 ----
 


### PR DESCRIPTION
This PR adds the newly required `iconName` interface method to the example.